### PR TITLE
Make deploying static sites optional

### DIFF
--- a/.github/workflows/github-pages-go-hugo.yaml
+++ b/.github/workflows/github-pages-go-hugo.yaml
@@ -2,6 +2,12 @@ name: "GitHub Pages - Hugo"
 
 on:
   workflow_call:
+    inputs:
+      deploy:
+        description: "Whether to deploy the built site"
+        default: ${{ github.ref == 'refs/heads/main' }}
+        required: false
+        type: boolean
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -32,6 +38,7 @@ jobs:
           path: ./public
 
   deploy:
+    if: ${{ inputs.deploy }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/github-pages-python-sphinx-with-pdf.yaml
+++ b/.github/workflows/github-pages-python-sphinx-with-pdf.yaml
@@ -2,6 +2,12 @@ name: "GitHub Pages - Python Sphinx - with PDF"
 
 on:
   workflow_call:
+    inputs:
+      deploy:
+        description: "Whether to deploy the built site"
+        default: ${{ github.ref == 'refs/heads/main' }}
+        required: false
+        type: boolean
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -46,6 +52,7 @@ jobs:
           path: ./docs/build/dirhtml
 
   deploy:
+    if: ${{ inputs.deploy }}
     environment:
       name: "github-pages"
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/github-pages-python-sphinx.yaml
+++ b/.github/workflows/github-pages-python-sphinx.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       deploy:
-        description: "Whether to deploy the built documentation"
+        description: "Whether to deploy the built site"
         default: ${{ github.ref == 'refs/heads/main' }}
         required: false
         type: boolean

--- a/.github/workflows/github-pages-rust-doc.yaml
+++ b/.github/workflows/github-pages-rust-doc.yaml
@@ -1,7 +1,13 @@
-name: GitHub Pages - Rust doc
+name: "GitHub Pages - Rust doc"
 
 on:
   workflow_call:
+    inputs:
+      deploy:
+        description: "Whether to deploy the built site"
+        default: ${{ github.ref == 'refs/heads/main' }}
+        required: false
+        type: boolean
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -26,6 +32,7 @@ jobs:
           path: ./target/doc
 
   deploy:
+    if: ${{ inputs.deploy }}
     environment:
       name: "github-pages"
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The artifact will still be uploaded and can be downloaded for manual review