### PR TITLE
Have Dependabot group dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,8 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      callable-workflows:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "workflow-templates"
     schedule:
       interval: "monthly"
+    groups:
+      template-workflows:
+        patterns:
+          - "*"


### PR DESCRIPTION
Let Dependabot automatically group all updates into a single PR.