### PR TITLE
Remove .lock file from docs build because it's causing permission errors

### DIFF
--- a/.github/workflows/github-pages-rust-doc.yaml
+++ b/.github/workflows/github-pages-rust-doc.yaml
@@ -20,6 +20,11 @@ jobs:
       - name: "Build docs with cargo"
         run: cargo doc --no-deps --document-private-items
 
+      # `.lock` is set to to rw-------, which causes actions/deploy-pages to fail
+      # because it's expecting all files to be at least rw-r--r--
+      - name: "Remove '.lock' file"
+        run: rm ./target/doc/.lock
+
       - name: "Upload artifact"
         uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
         with:


### PR DESCRIPTION
Closes #70 by deleting the lockfile.