### PR TITLE
python-lint: ruff: --format was renamed to --output-format

### DIFF
--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -28,4 +28,4 @@ jobs:
         run: black --check src/
 
       - name: "Run ruff"
-        run: "python -m ruff check --format=github src/"
+        run: python -m ruff check --output-format=github src/


### PR DESCRIPTION
astral-sh/ruff#7514