### PR TITLE
Don't install Python packages in editable mode

### DIFF
--- a/.github/workflows/github-pages-python-sphinx.yaml
+++ b/.github/workflows/github-pages-python-sphinx.yaml
@@ -25,7 +25,7 @@ jobs:
           cache-dependency-path: "pyproject.toml"
 
       - name: "Install dependencies"
-        run: pip install --editable .[docs]
+        run: pip install .[docs]
 
       - name: "Build docs"
         run: |

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -22,7 +22,7 @@ jobs:
         run: python -m pip install --upgrade pip wheel setuptools build
 
       - name: "Install dependencies"
-        run: python -m pip install --editable .[dev,tests]
+        run: python -m pip install .[dev,tests]
 
       - name: "Check formatting"
         run: black --check src/

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -30,7 +30,7 @@ jobs:
         run: python -m pip install --upgrade pip wheel setuptools build
 
       - name: "Install dependencies"
-        run: python -m pip install --editable .[tests]
+        run: python -m pip install .[tests]
 
       - name: "Run tests"
         run: python -m pytest


### PR DESCRIPTION
We want to test against the same format that they will be used in production.