### PR TITLE
Update Docker workflow to expect a 'Containerfile'

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -26,9 +26,6 @@ jobs:
       id-token: write
 
     steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-
       - name: "Install cosign"
         uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
         with:
@@ -58,7 +55,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
-          context: .
+          file: Containerfile
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Use `Containerfile` instead of `Dockerfile`

Also remove the call to `actions/checkout` because
> By default, this action uses the [Git context](https://docs.docker.com/engine/reference/commandline/build/#git-repositories), so you don't need to use the [actions/checkout](https://github.com/actions/checkout/) action to check out the repository as this will be done directly by [BuildKit](https://github.com/moby/buildkit).

I'm not going to rename the other assorted references to Docker at this time, as we're still using their actions.