### PR TITLE
Limit Python CI template to only test on Linux

### DIFF
--- a/workflow-templates/python-ci.yaml
+++ b/workflow-templates/python-ci.yaml
@@ -15,7 +15,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ "3.11" ]
 
     uses: darbiadev/.github/.github/workflows/python-test.yaml@068870f051676db9e2651013f7c7196ffdaeadaa # v2.0.0


### PR DESCRIPTION
Individual projects can add more platforms, as necessary.