### PR TITLE
Don't use built-in caching for pre-commit

### DIFF
--- a/.github/workflows/generic-precommit.yaml
+++ b/.github/workflows/generic-precommit.yaml
@@ -32,8 +32,6 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           allow-prereleases: true
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
 
       # This step caches our Python dependencies. To make sure we
       # only restore a cache when the dependencies, the python version,


### PR DESCRIPTION
v3.2.0 broke the pre-commit workflow by letting the `setup-python` action attempt to create a cache despite `PIP_NO_CACHE_DIR` being explicitly set.