### PR TITLE
Bump Cosign to v1.13.6

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: "Install cosign"
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:
-          cosign-release: "v1.13.2"
+          cosign-release: "v1.13.6"
 
       - name: "Setup Docker buildx"
         uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0


### PR DESCRIPTION
https://github.com/sigstore/cosign/releases/tag/v1.13.6

Where did .3, .4, and .5 go?